### PR TITLE
Fix localWiFiStatusForFlags for 64-bit iOS

### DIFF
--- a/src/ios/CDVReachability.m
+++ b/src/ios/CDVReachability.m
@@ -190,7 +190,7 @@ static void CDVReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRe
 {
     CDVPrintReachabilityFlags(flags, "localWiFiStatusForFlags");
 
-    BOOL retVal = NotReachable;
+    NetworkStatus retVal = NotReachable;
     if ((flags & kSCNetworkReachabilityFlagsReachable) && (flags & kSCNetworkReachabilityFlagsIsDirect)) {
         retVal = ReachableViaWiFi;
     }


### PR DESCRIPTION
Complete fix for https://issues.apache.org/jira/browse/CB-6350 by using using NetworkStatus type instead of BOOL in method: localWiFiStatusForFlags
